### PR TITLE
Added break after call to ERROR macro in switches

### DIFF
--- a/test.c
+++ b/test.c
@@ -20,39 +20,39 @@ int main()
     create_interval(&c, "Test 3", mono, UNITS);
 
     printf("Running '%s'\n", a->name);
-    
+
     start(a);
     nanosleep((struct timespec[]){{1, 0}}, NULL);
     stop(a);
-    
-    printf("RAW:\n START: %lld.%.9ld\n END: %lld.%.9ld\n", (long long) a->start.tv_sec, a->start.tv_nsec, (long long) a->stop.tv_sec, a->stop.tv_nsec); 
+
+    printf("RAW:\n START: %lld.%.9ld\n END: %lld.%.9ld\n", (long long) a->start.tv_sec, a->start.tv_nsec, (long long) a->stop.tv_sec, a->stop.tv_nsec);
     printf("OUT: %.9f %s\n", elapsed_interval(a, none), print_unit(a->unit));
     printf("EXPECTED: 1 sec\n");
-    
+
     printf("Running '%s'\n", b->name);
-    
+
     start(b);
     nanosleep((struct timespec[]){{1, MILLI_TO_NSEC(500)}}, NULL);
     stop(b);
-    
-    printf("RAW:\n START: %lld.%.9ld\n END: %lld.%.9ld\n", (long long) b->start.tv_sec, b->start.tv_nsec, (long long) b->stop.tv_sec, b->stop.tv_nsec); 
+
+    printf("RAW:\n START: %lld.%.9ld\n END: %lld.%.9ld\n", (long long) b->start.tv_sec, b->start.tv_nsec, (long long) b->stop.tv_sec, b->stop.tv_nsec);
     printf("OUT: %.9f %s\n", elapsed_interval(b, none), print_unit(b->unit));
-    
+
     printf("Running '%s'\n", c->name);
     printf("EXPECTED: 1.5 sec\n");
-    
+
     start(c);
     nanosleep((struct timespec[]){{2, MILLI_TO_NSEC(756)}}, NULL);
     stop(c);
-    
-    printf("RAW:\n START: %lld.%.9ld\n END: %lld.%.9ld\n", (long long) c->start.tv_sec, c->start.tv_nsec, (long long) c->stop.tv_sec, c->stop.tv_nsec); 
+
+    printf("RAW:\n START: %lld.%.9ld\n END: %lld.%.9ld\n", (long long) c->start.tv_sec, c->start.tv_nsec, (long long) c->stop.tv_sec, c->stop.tv_nsec);
     printf("OUT: %.9f %s\n", elapsed_interval(c, none), print_unit(c->unit));
     printf("EXPECTED: 2.756 sec\n");
-    
+
     printf("FINAL TEST\n");
     print_results(3, a, b, c);
     print_results_csv("#", 3, a, b, c);
-   
+
     free(a);
     free(b);
     free(c);

--- a/timer.c
+++ b/timer.c
@@ -78,6 +78,7 @@ clockid_t set_clock(clock_e ck)
 #endif
         default:
             ERROR("Invalid CLOCK value, using CLOCK_REALTIME");
+            break;
         case rt:
             clock = CLOCK_REALTIME;
             break;
@@ -118,7 +119,7 @@ struct timespec diff_timespec(struct timespec end, struct timespec begin)
     return result;
 }
 
-/* 
+/*
  * XXX: This is a bit of unnecessary toil, however it does the job...
  * An inline solution would be more practical... but I can't
  * remember how to do it with a struct...
@@ -146,11 +147,12 @@ error:
  */
 inline
 char * print_unit(unit_e unit)
-{   
+{
     switch(unit)
     {
         default:
             ERROR("Invalid UNIT value, using seconds (s)");
+            break;
         case 0:
             return (char *) "s";
             break;
@@ -186,7 +188,7 @@ int create_interval(interval_t ** tmp, char * name, clock_e ck, unit_e ut)
     (*tmp)->clock = ck;
     (*tmp)->unit = ut;
     return OK;
-    
+
 error:
     if(*tmp) free(*tmp);
     return NOT_ALLOCATED;
@@ -257,6 +259,7 @@ double elapsed_interval(interval_t * tmp, unit_e ut)
     {
         default:
             ERROR("Invalid UNIT value, using seconds (s)");
+            break;
         case s:
             time = (double) diff.tv_sec + NANO_TO_SEC(diff.tv_nsec);
             break;
@@ -303,7 +306,7 @@ void print_results(int num, ...)
         printf("%s: %.3f %s\n", names[i], values[i], print_unit(units[i]));
         free(names[i]);
     }
-} 
+}
 
 /* Function
  *  this function prints out the elapsed time(s) from the given interval(s).

--- a/timer.h
+++ b/timer.h
@@ -106,7 +106,7 @@ typedef enum
     rtc,
  /* - CLOCK_REALTIME_COARSE   (Linux only!)
   *       A faster but less precise version of CLOCK_REALTIME. Use when you
-  *       need very fast, but not fine-grained timestamps. 
+  *       need very fast, but not fine-grained timestamps.
   */
     mono,
  /* - CLOCK_MONOTONIC         (Linux only!)
@@ -119,7 +119,7 @@ typedef enum
     monoc,
  /* - CLOCK_MONOTONIC_COARSE  (Linux only!)
   *       A faster but less precise version of CLOCK_MONOTONIC. Use when you
-  *       need very fast, but not fine-grained timestamps. 
+  *       need very fast, but not fine-grained timestamps.
   */
     monor,
  /* - CLOCK_MONOTONIC_RAW     (Linux only!)
@@ -141,12 +141,12 @@ typedef enum
   */
     cput
  /* - CLOCK_THREAD_CPUTIME_ID
-  *       Thread-specific CPU-time clock. 
+  *       Thread-specific CPU-time clock.
   */
 } clock_e;
 
 /* Datatype
- *  struct interval -> 
+ *  struct interval ->
  *   - name -> string
  *   - start -> struct timespec
  *   - stop -> struct timespec


### PR DESCRIPTION
The missing break caused gcc 8.3.1 to warn about the statement falling through.

The other changes you see are just syntactic where blank spaces in the source.